### PR TITLE
CI #51 fix copy/paste typo

### DIFF
--- a/.github/workflows/init_repo.yml
+++ b/.github/workflows/init_repo.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Run init_repo.sh
         run: |
-          .github/workflows/init_repo.sh ${{ github.repository }}
+          bash .github/workflows/init_repo.sh ${{ github.repository }}
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/init_repo.yml
+++ b/.github/workflows/init_repo.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Run init_repo.sh
         run: |
-          .github/workflows/create_project.sh ${{ github.repository }}
+          .github/workflows/init_repo.sh ${{ github.repository }}
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
The template-sync job failed for [`prj_BITS`](https://github.com/prjemian/prj_BITS/pull/4) on this typo in PR #51.