### PR TITLE
Remove double-negative logic

### DIFF
--- a/src/apsbits/core/instrument_init.py
+++ b/src/apsbits/core/instrument_init.py
@@ -81,14 +81,14 @@ def make_devices(
             " also be provided"
         )
 
-    if path is not None:
-        configs_path = pathlib.Path(path)
-        print(f"\n\nConfigs path: {configs_path}\n\n")
-
-    else:
+    if path is None:
         iconfig = get_config()
         instrument_path = pathlib.Path(iconfig.get("INSTRUMENT_PATH")).parent
         configs_path = instrument_path / "configs"
+
+    else:
+        configs_path = pathlib.Path(path)
+        print(f"\n\nConfigs path: {configs_path}\n\n")
 
     device_file = file
 


### PR DESCRIPTION
Double-negative logic found here: https://github.com/BCDA-APS/BITS/blob/e99e3f9a95078ece480def7349ed787cc15ddfe1/src/apsbits/core/instrument_init.py#L84-L91

Re-arrange to clarify.