### PR TITLE
MNT remove redundant code; see init_catalog()

### DIFF
--- a/src/apsbits/demo_instrument/startup.py
+++ b/src/apsbits/demo_instrument/startup.py
@@ -63,10 +63,6 @@ register_bluesky_magics()
 
 # Bluesky initialization block
 
-if iconfig.get("TILED_PROFILE_NAME", {}):
-    profile_name = iconfig.get("TILED_PROFILE_NAME")
-    tiled_client = from_profile(profile_name)
-
 bec, peaks = init_bec_peaks(iconfig)
 cat = init_catalog(iconfig)
 RE, sd = init_RE(iconfig, subscribers=[bec, cat])

--- a/src/apsbits/demo_instrument/startup.py
+++ b/src/apsbits/demo_instrument/startup.py
@@ -14,8 +14,6 @@ import logging
 from pathlib import Path
 
 # Core Functions
-from tiled.client import from_profile
-
 from apsbits.core.best_effort_init import init_bec_peaks
 from apsbits.core.catalog_init import init_catalog
 from apsbits.core.instrument_init import init_instrument


### PR DESCRIPTION
The `tiled_client` is not used in `startup.py` now.  This is handled by `apsbits.core.init_catalog()` now.